### PR TITLE
Fix nested and sibling components

### DIFF
--- a/packages/mdx/src/server/__tests__/metro-transformer.test.ts
+++ b/packages/mdx/src/server/__tests__/metro-transformer.test.ts
@@ -70,6 +70,62 @@ describe(transform, () => {
     `);
   });
 
+  it(`should transform MDX with sibling and nested custom components`, async () => {
+    const result = await transform({
+      filename: "test.mdx",
+      //   src: `- 123`,
+      src: `
+# Hello World
+
+import Foo from './foo'
+
+<Foo />
+<Foo />
+
+<Foo>
+  <Foo />
+</Foo>`,
+    });
+
+    expect(result.src).toMatchInlineSnapshot(`
+      "\\"use client\\";
+      import { useMDXComponents } from \\"@bacons/mdx\\";
+
+      const makeExpoMetroProvided = name => function MDXExpoMetroComponent({ __components, ...props}) {
+        if (__components[name] == null) {
+          console.warn(\\"Component \\" + name + \\" was not imported, exported, or provided by MDXProvider as global scope\\")
+          return <__components.span {...props}/>
+        }
+        return __components[name](props);
+      };
+      import Foo from './foo'
+
+
+      const layoutProps = {
+        
+      };
+      const MDXLayout = \\"wrapper\\"
+      export default function MDXContent({
+        components,
+        ...props
+      }) {
+        const html = { ...useMDXComponents(), ...(components ?? {}) };
+        const MDXLayout = html.Wrapper;
+        return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+          <html.h1>{\`Hello World\`}</html.h1>
+
+          <Foo __components={html} mdxType=\\"Foo\\" />
+          <Foo __components={html} mdxType=\\"Foo\\" />
+          <Foo __components={html} mdxType=\\"Foo\\">
+        <Foo __components={html} mdxType=\\"Foo\\" />
+          </Foo>
+          </MDXLayout>;
+      }
+      ;
+      MDXContent.isMDXComponent = true;"
+    `);
+  });
+
   it(`should transform MDX with custom components`, async () => {
     const result = await transform({
       filename: "test.mdx",

--- a/packages/mdx/src/server/metro-transformer.ts
+++ b/packages/mdx/src/server/metro-transformer.ts
@@ -69,8 +69,8 @@ export function createTransformer({
             return;
           }
           if (node.value.match(/<([A-Z][\w.]+)/)) {
-            node.value = node.value.replace(
-              /<([A-Z][\w.]+)/,
+            node.value = node.value.replaceAll(
+              /<([A-Z][\w.]+)/g,
               `<$1 __components={html} `
             );
           }


### PR DESCRIPTION
There was a bug where only the first custom component was having the `__components` prop added. This PR adds it to all custom components (whether they're siblings or nested).