### PR TITLE
Update test snapshots

### DIFF
--- a/packages/mdx/src/server/__tests__/metro-transformer.test.ts
+++ b/packages/mdx/src/server/__tests__/metro-transformer.test.ts
@@ -28,7 +28,8 @@ describe(transform, () => {
       true
     );
     expect(result.src).toMatchInlineSnapshot(`
-      "import { useMDXComponents } from \\"@bacons/mdx\\";
+      "\\"use client\\";
+      import { useMDXComponents } from \\"@bacons/mdx\\";
 
       const makeExpoMetroProvided = name => function MDXExpoMetroComponent({ __components, ...props}) {
         if (__components[name] == null) {
@@ -83,7 +84,8 @@ import Foo from './foo'
     });
 
     expect(result.src).toMatchInlineSnapshot(`
-      "import { useMDXComponents } from \\"@bacons/mdx\\";
+      "\\"use client\\";
+      import { useMDXComponents } from \\"@bacons/mdx\\";
 
       const makeExpoMetroProvided = name => function MDXExpoMetroComponent({ __components, ...props}) {
         if (__components[name] == null) {
@@ -127,7 +129,8 @@ import Foo from './foo'
     });
 
     expect(result.src).toMatchInlineSnapshot(`
-      "import { useMDXComponents } from \\"@bacons/mdx\\";
+      "\\"use client\\";
+      import { useMDXComponents } from \\"@bacons/mdx\\";
 
       const makeExpoMetroProvided = name => function MDXExpoMetroComponent({ __components, ...props}) {
         if (__components[name] == null) {


### PR DESCRIPTION
It seems like the test snapshots were out of date, so I've updated them here.

I ran `yarn test` and then typed `u` to update them in the interactive Jest watcher.