### PR TITLE
Fix `role` for <h1> etc

### DIFF
--- a/packages/mdx/src/react/headings.tsx
+++ b/packages/mdx/src/react/headings.tsx
@@ -16,7 +16,7 @@ function createHeadingComponent(level: number): ComponentType<TextProps> {
   const nativeProps: any = Platform.select({
     web: {
       "aria-level": level,
-      role: "header",
+      role: "heading",
     },
     default: {
       accessibilityRole: "header",


### PR DESCRIPTION
The value should be `heading` not `header` see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role